### PR TITLE
Enable SQLite FTS5 support for full-text search

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -258,12 +258,12 @@ sqlite3/sqlite3/sqlite3.o:
 	cd sqlite3/sqlite3 && patch -p0 < ../from_unixtime.patch
 	cd sqlite3/sqlite3 && patch -p0 < ../sqlite3_pass_exts.patch
 	cd sqlite3/sqlite3 && patch -p0 < ../throw.patch
-	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o sqlite3.o sqlite3.c -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_DLL=1
+	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o sqlite3.o sqlite3.c -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DSQLITE_DLL=1
 	cd sqlite3/sqlite3 && ${CC} -shared -o libsqlite3.so sqlite3.o
 
 sqlite3/sqlite3/vec.o: sqlite3/sqlite3/sqlite3.o
 	cd sqlite3/sqlite3 && cp ../sqlite-vec-source/sqlite-vec.c . && cp ../sqlite-vec-source/sqlite-vec.h .
-	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o vec.o sqlite-vec.c -DSQLITE_CORE -DSQLITE_VEC_STATIC -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_DLL=1
+	cd sqlite3/sqlite3 && ${CC} ${MYCFLAGS} -fPIC -c -o vec.o sqlite-vec.c -DSQLITE_CORE -DSQLITE_VEC_STATIC -DSQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DSQLITE_DLL=1
 
 sqlite3/libsqlite_rembed.a: sqlite3/sqlite-rembed-0.0.1-alpha.9.tar.gz
 	cd sqlite3 && rm -rf sqlite-rembed-*/ sqlite-rembed-source/ || true


### PR DESCRIPTION
## Summary
- Adds `-DSQLITE_ENABLE_FTS5` compilation flag to SQLite build in `deps/Makefile`
- Enables SQLite's FTS5 (Full-Text Search) extension for vector search enhanced ProxySQL

## Changes
Modified `deps/Makefile` at lines 261 and 266:
1. `sqlite3.o` compilation: Added `-DSQLITE_ENABLE_FTS5` flag alongside existing `-DSQLITE_ENABLE_MEMORY_MANAGEMENT` and `-DSQLITE_ENABLE_JSON1` flags
2. `vec.o` compilation: Added `-DSQLITE_ENABLE_FTS5` flag for consistency with sqlite3.o

## Technical Details
- FTS5 is SQLite's built-in full-text search engine (version 5)
- Enables creation of virtual tables for full-text indexing and searching
- Compatible with existing SQLite vector search features
- Requires rebuilding ProxySQL main binary to link against updated SQLite library

## Verification
- Compiled successfully with `make sqlite3`
- FTS5 symbols present in `sqlite3.o` (confirmed via `nm` output)
- No breaking changes to existing functionality

## Test Plan
- [ ] Rebuild ProxySQL with updated dependencies
- [ ] Verify FTS5 functions available in SQLite queries
- [ ] Test full-text search capabilities alongside vector search