### PR TITLE
fix: Re-enable SQLite3DB::LoadPlugin() with allow_load_plugin flag

### DIFF
--- a/lib/sqlite3db.cpp
+++ b/lib/sqlite3db.cpp
@@ -1065,14 +1065,15 @@ SQLite3_result::SQLite3_result() {
 
 /**
  * @brief Loads a SQLite3 plugin.
- * 
+ *
  * This function loads a SQLite3 plugin specified by the given plugin_name.
  * It initializes function pointers to SQLite3 API functions provided by the plugin.
  * If the plugin_name is NULL, it loads the built-in SQLite3 library and initializes function pointers to its API functions.
- * 
+ *
  * @param[in] plugin_name The name of the SQLite3 plugin library to load.
  */
 void SQLite3DB::LoadPlugin(const char *plugin_name) {
+	const bool allow_load_plugin = false; // TODO: Revisit plugin loading safety mechanism
 	proxy_sqlite3_config = NULL;
 	proxy_sqlite3_bind_double = NULL;
 	proxy_sqlite3_bind_int = NULL;
@@ -1109,7 +1110,7 @@ void SQLite3DB::LoadPlugin(const char *plugin_name) {
 	proxy_sqlite3_prepare_v2 = NULL;
 	proxy_sqlite3_open_v2 = NULL;
 	proxy_sqlite3_exec = NULL;
-	if (plugin_name) {
+	if (plugin_name && allow_load_plugin == true) {
 		int fd = -1;
 		fd = ::open(plugin_name, O_RDONLY);
 		char binary_sha1_sqlite3[SHA_DIGEST_LENGTH*2+1];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1381,20 +1381,7 @@ void ProxySQL_Main_init() {
 static void LoadPlugins() {
 	GloMyLdapAuth = NULL;
 	if (proxy_sqlite3_open_v2 == nullptr) {
-		if (GloVars.sqlite3_plugin) {
-			proxy_warning("SQLite3 plugin loading disabled: function replacement is temporarily disabled for plugin: %s\n", GloVars.sqlite3_plugin);
-		} else {
-			proxy_warning("SQLite3 plugin function replacement is disabled; no sqlite3 plugin specified\n");
-		}
-		/*
-	 * Temporarily disabled: do not replace proxy_sqlite3_* symbols from plugins because
-	 * this can change core sqlite3 behavior unexpectedly. The original call is kept
-	 * here for reference and to make re-enabling trivial in the future.
-	 * TODO: Revisit plugin function replacement and implement a safer mechanism
-	 * for plugin-provided sqlite3 capabilities (create a ticket/PR and reference it here).
-	 */
-	// SQLite3DB::LoadPlugin(GloVars.sqlite3_plugin);
-
+		SQLite3DB::LoadPlugin(GloVars.sqlite3_plugin);
 	}
 	if (GloVars.web_interface_plugin) {
 		dlerror();


### PR DESCRIPTION
## Problem

In PR #22, the call to `SQLite3DB::LoadPlugin()` was completely disabled. This was incorrect because the function performs important initialization even when no plugin is specified—it initializes all the `proxy_sqlite3_*` function pointers from the built-in SQLite3 library.

## Solution

This fix:
1. **Re-enables the `LoadPlugin()` call** in `src/main.cpp`
2. **Adds a safety flag** `allow_load_plugin = false` in `lib/sqlite3db.cpp`
3. **Modifies the plugin loading check** from `if (plugin_name)` to `if (plugin_name && allow_load_plugin == true)`

## Behavior

- ✅ `LoadPlugin()` now runs and initializes function pointers from built-in SQLite3
- ✅ Actual plugin loading remains disabled (`allow_load_plugin = false`) for safety
- ✅ TODO comment added to revisit the plugin loading safety mechanism

## Testing

After this fix, the proxy_sqlite3_* function pointers are properly initialized on startup, fixing crashes that occurred when these functions were called with NULL pointers.

Fixes issue introduced in #22